### PR TITLE
feat: mark login fields for password manager support

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,25 +18,22 @@
     
     <div id="foreground">
         <div id="credentials-container">
-            <div>
+            <form id="login-form" autocomplete="on">
                 <div id="login">
-                    
-                    <div><input type="text" id="username" placeholder="Email"></div>
+                    <div><input type="email" id="username" name="username" placeholder="Email" autocomplete="username" required></div>
                 </div>
                 <div id="login">
-                    
-                    <div><input type="password" id="password" placeholder="Password"></div>
+                    <div><input type="password" id="password" name="password" placeholder="Password" autocomplete="current-password" required></div>
                 </div>
-            </div>
-            <div id="submit">
-                <img src="image/logo.png" alt="vermac button" class="vermac-button-image" id="save-credentials">
-                
-                
-            </div>
-            <div id="CredentialText">
-                <label>Inserting wrong credentials won't allow you to continue.</label>
-            </div>
-            
+                <div id="submit">
+                    <button type="submit" id="save-credentials">
+                        <img src="image/logo.png" alt="vermac button" class="vermac-button-image">
+                    </button>
+                </div>
+                <div id="CredentialText">
+                    <label>Inserting wrong credentials won't allow you to continue.</label>
+                </div>
+            </form>
         </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -186,7 +186,8 @@ function initializeDOMContentLoaded() {
 
 
 
-document.getElementById('save-credentials').addEventListener('click', () => {
+document.getElementById('login-form').addEventListener('submit', (event) => {
+    event.preventDefault();
     const username = document.getElementById('username').value;
     const password = document.getElementById('password').value;
 

--- a/styles.css
+++ b/styles.css
@@ -517,6 +517,13 @@ body {
     scale: 1.35;
 }
 
+#submit button {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: inherit;
+}
+
 
 
 .speedKit {


### PR DESCRIPTION
## Summary
- wrap authentication inputs in a form
- add username and password field attributes for browser/1Password recognition
- style submit button accordingly and adjust login JS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a48c6d3c04832a8121dc92741956cf