### PR TITLE
feat: add sticky labels and hourly axis to heatmap

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,8 +135,12 @@
         <button class="close-btn" id="close-heatmap">&times;</button>
         <div class="heatmap-content">
             <h2>Device Data Heatmap</h2>
-            <div class="heatmap-scroll">
-                <canvas id="heatmap-canvas"></canvas>
+            <div class="heatmap-container">
+                <canvas id="heatmap-labels"></canvas>
+                <div class="heatmap-scroll">
+                    <canvas id="heatmap-axis"></canvas>
+                    <canvas id="heatmap-canvas"></canvas>
+                </div>
             </div>
         </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -614,8 +614,29 @@ body {
     margin-top: 20px;
 }
 
+#heatmap-panel .heatmap-container {
+    display: flex;
+    align-items: flex-start;
+}
+
+#heatmap-labels {
+    background: #fff;
+    border: 1px solid #444;
+    border-right: none;
+    display: block;
+    margin-top: 20px;
+}
+
+#heatmap-axis {
+    background: #fff;
+    border: 1px solid #444;
+    border-left: none;
+    display: block;
+}
+
 #heatmap-canvas {
     background: #fff;
     border: 1px solid #444;
+    border-left: none;
     display: block;
 }


### PR DESCRIPTION
## Summary
- keep device labels fixed while scrolling heatmap
- show hourly grid lines with labeled x-axis

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68a4b9e4f1c4832a8bdf9318822b52c6